### PR TITLE
make sure original API is not changed

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -105,7 +105,16 @@ int main (int argc, char **argv) {
     }
     
     strncpy(multi_fasta_filename, argv[optind], FILENAME_MAX); 
-    generate_snp_sites(multi_fasta_filename, output_multi_fasta_file, output_vcf_file, output_phylip_file, output_filename, output_reference);
+    if (output_reference) {
+      generate_snp_sites_with_ref(multi_fasta_filename,
+                                  output_multi_fasta_file,
+                                  output_vcf_file, output_phylip_file,
+                                  output_filename);
+    } else {
+      generate_snp_sites(multi_fasta_filename, output_multi_fasta_file,
+                         output_vcf_file, output_phylip_file,
+                         output_filename);
+    }
   }
   else
   {

--- a/src/snp-sites.c
+++ b/src/snp-sites.c
@@ -1,6 +1,6 @@
 /*
  *  Wellcome Trust Sanger Institute
- *  Copyright (C) 2013  Wellcome Trust Sanger Institute
+ *  Copyright (C) 2013-2016 Wellcome Trust Sanger Institute
  *  
  *  This program is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU General Public License
@@ -17,8 +17,6 @@
  *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -29,7 +27,12 @@
 #include "phylib-of-snp-sites.h"
 #include "fasta-of-snp-sites.h"
 
-int generate_snp_sites(char filename[],int output_multi_fasta_file, int output_vcf_file, int output_phylip_file, char output_filename[], int output_reference)
+static int generate_snp_sites_generic(char filename[],
+                                      int output_multi_fasta_file,
+                                      int output_vcf_file,
+                                      int output_phylip_file,
+                                      char output_filename[],
+                                      int output_reference)
 {
 	int i;
 	detect_snps(filename);
@@ -101,6 +104,24 @@ int generate_snp_sites(char filename[],int output_multi_fasta_file, int output_v
   free(get_pseudo_reference_sequence());
 
 	return 1;
+}
+
+int generate_snp_sites(char filename[], int output_multi_fasta_file,
+                       int output_vcf_file, int output_phylip_file,
+                       char output_filename[])
+{
+  return generate_snp_sites_generic(filename, output_multi_fasta_file,
+                                    output_vcf_file, output_phylip_file,
+                                    output_filename, 0);
+}
+
+int generate_snp_sites_with_ref(char filename[], int output_multi_fasta_file,
+                                int output_vcf_file, int output_phylip_file,
+                                char output_filename[])
+{
+    return generate_snp_sites_generic(filename, output_multi_fasta_file,
+                                      output_vcf_file, output_phylip_file,
+                                      output_filename, 1);
 }
 
 // Inefficient

--- a/src/snp-sites.h
+++ b/src/snp-sites.h
@@ -1,6 +1,6 @@
 /*
  *  Wellcome Trust Sanger Institute
- *  Copyright (C) 2013  Wellcome Trust Sanger Institute
+ *  Copyright (C) 2013-2016  Wellcome Trust Sanger Institute
  *  
  *  This program is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU General Public License
@@ -23,7 +23,17 @@
 
 #include <stdio.h>
 
-int generate_snp_sites(char filename[],int output_multi_fasta_file, int output_vcf_file, int output_phylip_file, char output_filename[], int output_reference);
-void strip_directory_from_filename(char * input_filename, char * output_filename);
+int generate_snp_sites(char filename[],
+                       int output_multi_fasta_file,
+                       int output_vcf_file,
+                       int output_phylip_file,
+                       char output_filename[]);
+int generate_snp_sites_with_ref(char filename[],
+                                int output_multi_fasta_file,
+                                int output_vcf_file,
+                                int output_phylip_file,
+                                char output_filename[]);
+void strip_directory_from_filename(char *input_filename,
+                                   char *output_filename);
 
 #endif

--- a/tests/check-snp-sites.c
+++ b/tests/check-snp-sites.c
@@ -36,7 +36,7 @@
 
 START_TEST (valid_alignment_with_one_line_per_sequence)
 {
-  generate_snp_sites("../tests/data/alignment_file_one_line_per_sequence.aln",1,1,1,"",0);
+  generate_snp_sites("../tests/data/alignment_file_one_line_per_sequence.aln",1,1,1,"");
   fail_unless( compare_files("../tests/data/alignment_file_one_line_per_sequence.aln.vcf", "alignment_file_one_line_per_sequence.aln.vcf" ) == 1, "Invalid VCF file for 1 line per seq" );
   fail_unless( compare_files("../tests/data/alignment_file_one_line_per_sequence.aln.phylip", "alignment_file_one_line_per_sequence.aln.phylip" ) == 1, "Invalid Phylip file for 1 line per seq" );
   fail_unless( compare_files("../tests/data/alignment_file_one_line_per_sequence.aln.snp_sites.aln","alignment_file_one_line_per_sequence.aln.snp_sites.aln" ) == 1 , "Invalid ALN file for 1 line per seq");
@@ -49,7 +49,7 @@ END_TEST
 
 START_TEST (valid_alignment_with_n_as_gap)
 {
-	  generate_snp_sites("../tests/data/alignment_file_with_n.aln",1,1,1, "",0);
+	  generate_snp_sites("../tests/data/alignment_file_with_n.aln",1,1,1, "");
 	  fail_unless( compare_files("../tests/data/alignment_file_with_n.aln.vcf", "alignment_file_with_n.aln.vcf" ) == 1, "Invalid VCF file for 1 line per seq" );
 	  fail_unless( compare_files("../tests/data/alignment_file_with_n.aln.phylip", "alignment_file_with_n.aln.phylip" ) == 1, "Invalid Phylip file for 1 line per seq" );
 	  fail_unless( compare_files("../tests/data/alignment_file_with_n.aln.snp_sites.aln","alignment_file_with_n.aln.snp_sites.aln" ) == 1 , "Invalid ALN file for 1 line per seq");
@@ -63,7 +63,7 @@ END_TEST
 
 START_TEST (valid_alignment_with_one_line_per_sequence_gzipped)
 {
-  generate_snp_sites("../tests/data/alignment_file_one_line_per_sequence.aln.gz",1,1,1, NULL,0);
+  generate_snp_sites("../tests/data/alignment_file_one_line_per_sequence.aln.gz",1,1,1, NULL);
   fail_unless( compare_files("../tests/data/alignment_file_one_line_per_sequence.aln.vcf", "alignment_file_one_line_per_sequence.aln.gz.vcf" ) == 1, "Invalid VCF file for 1 line per seq" );
   fail_unless( compare_files("../tests/data/alignment_file_one_line_per_sequence.aln.phylip", "alignment_file_one_line_per_sequence.aln.gz.phylip" ) == 1, "Invalid Phylip file for 1 line per seq" );
   fail_unless( compare_files("../tests/data/alignment_file_one_line_per_sequence.aln.snp_sites.aln","alignment_file_one_line_per_sequence.aln.gz.snp_sites.aln" ) == 1 , "Invalid ALN file for 1 line per seq");
@@ -75,7 +75,7 @@ END_TEST
 
 START_TEST (valid_alignment_with_multiple_lines_per_sequence)
 {
-    generate_snp_sites("../tests/data/alignment_file_multiple_lines_per_sequence.aln",1,1,1,"",0);
+    generate_snp_sites("../tests/data/alignment_file_multiple_lines_per_sequence.aln",1,1,1,"");
     fail_unless( compare_files("../tests/data/alignment_file_one_line_per_sequence.aln.vcf", "alignment_file_multiple_lines_per_sequence.aln.vcf" ) == 1, "Invalid VCF file for multiple lines per seq" );
     fail_unless( compare_files("../tests/data/alignment_file_one_line_per_sequence.aln.phylip", "alignment_file_multiple_lines_per_sequence.aln.phylip" ) == 1, "Invalid Phylip file for multiple lines per seq" );
     fail_unless( compare_files("../tests/data/alignment_file_one_line_per_sequence.aln.snp_sites.aln","alignment_file_multiple_lines_per_sequence.aln.snp_sites.aln" ) == 1 ,"Invalid ALN file for multiple lines per seq");
@@ -87,7 +87,7 @@ END_TEST
 
 START_TEST (valid_with_only_aln_file_output_default)
 {
-	    generate_snp_sites("../tests/data/alignment_file_one_line_per_sequence.aln",0,0,0,"",0);
+	    generate_snp_sites("../tests/data/alignment_file_one_line_per_sequence.aln",0,0,0,"");
 	    fail_unless( compare_files("../tests/data/alignment_file_one_line_per_sequence.aln.snp_sites.aln","alignment_file_one_line_per_sequence.aln.snp_sites.aln" ) == 1 ,"Invalid ALN file for multiple lines per seq");
 	    remove("alignment_file_one_line_per_sequence.aln.snp_sites.aln");
 }
@@ -95,7 +95,7 @@ END_TEST
 
 START_TEST (valid_with_only_aln_file_output)
 {
-	    generate_snp_sites("../tests/data/alignment_file_one_line_per_sequence.aln",1,0,0,"",0);
+	    generate_snp_sites("../tests/data/alignment_file_one_line_per_sequence.aln",1,0,0,"");
 	    fail_unless( compare_files("../tests/data/alignment_file_one_line_per_sequence.aln.snp_sites.aln","alignment_file_one_line_per_sequence.aln.snp_sites.aln" ) == 1 ,"Invalid ALN file for multiple lines per seq");
 	    remove("alignment_file_one_line_per_sequence.aln.snp_sites.aln");
 }
@@ -104,7 +104,7 @@ END_TEST
 START_TEST (valid_with_only_aln_file_output_with_custom_name)
 {
 	char output_filename[100] = {"some_custom_name"};
-	    generate_snp_sites("../tests/data/alignment_file_multiple_lines_per_sequence.aln",1,0,0,output_filename,0);
+	    generate_snp_sites("../tests/data/alignment_file_multiple_lines_per_sequence.aln",1,0,0,output_filename);
 	    fail_unless( compare_files("../tests/data/alignment_file_one_line_per_sequence.aln.snp_sites.aln","some_custom_name" ) == 1 ,"Only aln with custom name should be outputted");
 	    remove("some_custom_name");
 }
@@ -112,7 +112,7 @@ END_TEST
 
 START_TEST (valid_with_phylip_outputted_with_custom_name)
 {
-  generate_snp_sites("../tests/data/alignment_file_one_line_per_sequence.aln",0,0,1,"some_custom_name",0);
+  generate_snp_sites("../tests/data/alignment_file_one_line_per_sequence.aln",0,0,1,"some_custom_name");
   fail_unless( compare_files("../tests/data/alignment_file_one_line_per_sequence.aln.phylip", "some_custom_name" ) == 1, "Custom name needs extra extension for phylip" );
   remove("some_custom_name");
 
@@ -121,14 +121,14 @@ END_TEST
 
 START_TEST (invalid_with_uneven_file_lengths)
 {
-	    generate_snp_sites("../tests/data/uneven_alignment.aln",1,0,0,"",0);
+	    generate_snp_sites("../tests/data/uneven_alignment.aln",1,0,0,"");
 }
 END_TEST
 
 
 START_TEST (valid_with_all_outputted_with_custom_name)
 {
-  generate_snp_sites("../tests/data/alignment_file_one_line_per_sequence.aln",1,1,1,"some_custom_name",0);
+  generate_snp_sites("../tests/data/alignment_file_one_line_per_sequence.aln",1,1,1,"some_custom_name");
   fail_unless( compare_files("../tests/data/alignment_file_one_line_per_sequence.aln.vcf", "some_custom_name.vcf" ) == 1, "Custom name needs extra extension for VCF" );
   fail_unless( compare_files("../tests/data/alignment_file_one_line_per_sequence.aln.phylip", "some_custom_name.phylip" ) == 1, "Custom name needs extra extension for phylip" );
   fail_unless( compare_files("../tests/data/alignment_file_one_line_per_sequence.aln.snp_sites.aln","some_custom_name.snp_sites.aln" ) == 1 , "Custom name needs extra extension for ALN");
@@ -141,7 +141,7 @@ END_TEST
   
 START_TEST (valid_aln_plus_reference)
 {
-	    generate_snp_sites("../tests/data/alignment_file_one_line_per_sequence.aln",1,0,0,"",1);
+	    generate_snp_sites_with_ref("../tests/data/alignment_file_one_line_per_sequence.aln",1,0,0,"");
 	    fail_unless( compare_files("../tests/data/alignment_file_one_line_per_sequence_reference.snp_sites.aln","alignment_file_one_line_per_sequence.aln.snp_sites.aln" ) == 1 ,"Invalid ALN file for multiple lines per seq");
 	    remove("alignment_file_one_line_per_sequence.aln.snp_sites.aln");
 }
@@ -149,7 +149,7 @@ END_TEST
 
 START_TEST (valid_phylip_plus_reference)
 {
-  generate_snp_sites("../tests/data/alignment_file_one_line_per_sequence.aln",0,0,1,"",1);
+  generate_snp_sites_with_ref("../tests/data/alignment_file_one_line_per_sequence.aln",0,0,1,"");
   fail_unless( compare_files("../tests/data/alignment_file_one_line_per_sequence_reference.aln.phylip", "alignment_file_one_line_per_sequence.aln.phylip" ) == 1, "invalid phylib with reference" );
   remove("alignment_file_one_line_per_sequence.aln.phylip");
 


### PR DESCRIPTION
The recent changes changed the API in a way that may influence the ABI in an unnecessary way. This PR restores the original function and adds new functionality in a new symbol, conserving the ABI.